### PR TITLE
Encadrement pour la confidence dans speechcommands

### DIFF
--- a/plugins/speechcommands/speechcommands.plugin.php
+++ b/plugins/speechcommands/speechcommands.plugin.php
@@ -181,7 +181,7 @@ function speechcommands_plugin_preference_page(){
 		<tr class="command">
 				
 				<td><?php echo $conf->get('VOCAL_ENTITY_NAME').', <input type="text" class="input-medium" value="'.$command->command.'" placeholder="ma phrase ici" name="command">' ?></td>
-				<td><input  type="number" step="any" class="input-mini" name="confidence" value="<?php echo $command->confidence; ?>"/></td>
+				<td><input  type="number" min="0" max="1" step=".01" class="input-mini" name="confidence" value="<?php echo $command->confidence; ?>"/></td>
 				<td>
 					<select name="type" class="type input-small">
 						<option <?php echo $command->action=='gpio'?'selected="selected"':''; ?> value="gpio">Changer un GPIO (sur le serveur)</option>


### PR DESCRIPTION
Ajout des attributs "max" et "min", ainsi que la modification de l'attribut "step" pour encadrer la valeur de la confidence entre 1 et 0 et mettre un pas de 0,01. Cela permet de ne plus pouvoir poster des valeurs de confidence négatives ou supérieures à 1.